### PR TITLE
Update readme and resolve splat warnings

### DIFF
--- a/ELBSample-ELBDefaultCipherPolicy/output.tf
+++ b/ELBSample-ELBDefaultCipherPolicy/output.tf
@@ -1,22 +1,22 @@
 output "id" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.id}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.id}"
 }
 
 output "name" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.name}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.name}"
 }
 
 output "load-balancer" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.load_balancer}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.load_balancer}"
   description = "The load balancer to which the policy is attached."
 }
 
 output "lb-port" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.lb_port}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.lb_port}"
   description = "The load balancer port to which the policy is applied. "
 }
 
 output "attribute" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.attribute}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.attribute}"
   description = "The SSL Negotiation policy attributes. "
 }

--- a/ELBSample-OpenSSLDefaultCipherPolicy/output.tf
+++ b/ELBSample-OpenSSLDefaultCipherPolicy/output.tf
@@ -1,22 +1,22 @@
 output "id" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.id}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.id}"
 }
 
 output "name" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.name}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.name}"
 }
 
 output "load-balancer" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.load_balancer}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.load_balancer}"
   description = "The load balancer to which the policy is attached."
 }
 
 output "lb-port" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.lb_port}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.lb_port}"
   description = "The load balancer port to which the policy is applied. "
 }
 
 output "attribute" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.attribute}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.attribute}"
   description = "The SSL Negotiation policy attributes. "
 }

--- a/ELBSecurityPolicy-2016-08/output.tf
+++ b/ELBSecurityPolicy-2016-08/output.tf
@@ -1,22 +1,22 @@
 output "id" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.id}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.id}"
 }
 
 output "name" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.name}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.name}"
 }
 
 output "load-balancer" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.load_balancer}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.load_balancer}"
   description = "The load balancer to which the policy is attached."
 }
 
 output "lb-port" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.lb_port}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.lb_port}"
   description = "The load balancer port to which the policy is applied. "
 }
 
 output "attribute" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.attribute}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.attribute}"
   description = "The SSL Negotiation policy attributes. "
 }

--- a/ELBSecurityPolicy-TLS-1-1-2017-01/output.tf
+++ b/ELBSecurityPolicy-TLS-1-1-2017-01/output.tf
@@ -1,22 +1,22 @@
 output "id" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.id}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.id}"
 }
 
 output "name" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.name}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.name}"
 }
 
 output "load-balancer" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.load_balancer}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.load_balancer}"
   description = "The load balancer to which the policy is attached."
 }
 
 output "lb-port" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.lb_port}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.lb_port}"
   description = "The load balancer port to which the policy is applied. "
 }
 
 output "attribute" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.attribute}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.attribute}"
   description = "The SSL Negotiation policy attributes. "
 }

--- a/ELBSecurityPolicy-TLS-1-2-2017-01/output.tf
+++ b/ELBSecurityPolicy-TLS-1-2-2017-01/output.tf
@@ -1,22 +1,22 @@
 output "id" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.id}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.id}"
 }
 
 output "name" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.name}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.name}"
 }
 
 output "load-balancer" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.load_balancer}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.load_balancer}"
   description = "The load balancer to which the policy is attached."
 }
 
 output "lb-port" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.lb_port}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.lb_port}"
   description = "The load balancer port to which the policy is applied. "
 }
 
 output "attribute" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.attribute}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.attribute}"
   description = "The SSL Negotiation policy attributes. "
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ resource "aws_elb" "lb" {
 }
 
 module "ssl-policy" {
-    source = "github.com/razorpay/terraform-ssl-ciphers//mozilla-old"
+    source = "github.com/razorpay/terraform-aws-ssl-ciphers//mozilla-old"
     name   = "${aws_elb.lb.name}-ssl-policy"
     load-balancer-id = "${aws_elb.lb.id}"
     lb-port = "443"
@@ -30,7 +30,7 @@ Or if you want to dynamically decide the policy:
 
 ```hcl
 module "ssl-policy" {
-    source = "github.com/razorpay/terraform-ssl-ciphers"
+    source = "github.com/razorpay/terraform-aws-ssl-ciphers"
     name = "${aws_elb.lb.name}-ssl-policy"
     load-balancer-id = "${aws_elb.lb.id}"
     policy = "mozilla-modern"

--- a/mozilla-intermediate/output.tf
+++ b/mozilla-intermediate/output.tf
@@ -1,22 +1,22 @@
 output "id" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.id}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.id}"
 }
 
 output "name" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.name}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.name}"
 }
 
 output "load-balancer" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.load_balancer}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.load_balancer}"
   description = "The load balancer to which the policy is attached."
 }
 
 output "lb-port" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.lb_port}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.lb_port}"
   description = "The load balancer port to which the policy is applied. "
 }
 
 output "attribute" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.attribute}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.attribute}"
   description = "The SSL Negotiation policy attributes. "
 }

--- a/mozilla-modern/output.tf
+++ b/mozilla-modern/output.tf
@@ -1,22 +1,22 @@
 output "id" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.id}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.id}"
 }
 
 output "name" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.name}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.name}"
 }
 
 output "load-balancer" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.load_balancer}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.load_balancer}"
   description = "The load balancer to which the policy is attached."
 }
 
 output "lb-port" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.lb_port}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.lb_port}"
   description = "The load balancer port to which the policy is applied. "
 }
 
 output "attribute" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.attribute}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.attribute}"
   description = "The SSL Negotiation policy attributes. "
 }

--- a/mozilla-old/output.tf
+++ b/mozilla-old/output.tf
@@ -1,22 +1,22 @@
 output "id" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.id}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.id}"
 }
 
 output "name" {
-  value = "${aws_lb_ssl_negotiation_policy.policy.name}"
+  value = "${aws_lb_ssl_negotiation_policy.policy.*.name}"
 }
 
 output "load-balancer" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.load_balancer}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.load_balancer}"
   description = "The load balancer to which the policy is attached."
 }
 
 output "lb-port" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.lb_port}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.lb_port}"
   description = "The load balancer port to which the policy is applied. "
 }
 
 output "attribute" {
-  value       = "${aws_lb_ssl_negotiation_policy.policy.attribute}"
+  value       = "${aws_lb_ssl_negotiation_policy.policy.*.attribute}"
   description = "The SSL Negotiation policy attributes. "
 }


### PR DESCRIPTION
Thanks so much for this repo, it's saved me a huge amount of time this evening!

Unfortunately, I'm getting warnings and errors when I'm running this. I'm using:

```
Terraform v0.11.8
+ provider.aws v1.31.0
+ provider.template v1.0.0
+ provider.terraform v1.0.0
```

Here's a warning:

Warning: output "attribute": must use splat syntax to access aws_lb_ssl_negotiation_policy.policy attribute "attribute", because it has "count" set; use aws_lb_ssl_negotiation_policy.policy.*.attribute to obtain a list of the attributes across all instances

And errors like this:

* module.(mymodulename).module.ssl-policy.module.mozilla-old.output.load-balancer: Resource 'aws_lb_ssl_negotiation_policy.policy' not found for variable 'aws_lb_ssl_negotiation_policy.policy.load_balancer'

I've found that by updating to use the splat, everything seems to work correctly. I'm not 100% sure on the implications of this - I guess it may affect other outputs, but it seems to work for my scenario.

I also noticed the readme hasn't changed since the update to the repo name, so I've popped that fix in too :)