### PR TITLE
Update for Terraform 0.12 module source syntax

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "ELBSample-OpenSSLDefaultCipherPolicy" {
   create           = "${var.policy == "ELBSample-OpenSSLDefaultCipherPolicy" ? "true" : "false"}"
-  source           = "ELBSample-OpenSSLDefaultCipherPolicy"
+  source           = "./ELBSample-OpenSSLDefaultCipherPolicy"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"
@@ -8,7 +8,7 @@ module "ELBSample-OpenSSLDefaultCipherPolicy" {
 
 module "mozilla-modern" {
   create           = "${var.policy == "mozilla-modern" ? "true" : "false"}"
-  source           = "mozilla-modern"
+  source           = "./mozilla-modern"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"
@@ -16,7 +16,7 @@ module "mozilla-modern" {
 
 module "ELBSecurityPolicy-TLS-1-1-2017-01" {
   create           = "${var.policy == "ELBSecurityPolicy-TLS-1-1-2017-01" ? "true" : "false"}"
-  source           = "ELBSecurityPolicy-TLS-1-1-2017-01"
+  source           = "./ELBSecurityPolicy-TLS-1-1-2017-01"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"
@@ -24,7 +24,7 @@ module "ELBSecurityPolicy-TLS-1-1-2017-01" {
 
 module "ELBSecurityPolicy-TLS-1-2-2017-01" {
   create           = "${var.policy == "ELBSecurityPolicy-TLS-1-2-2017-01" ? "true" : "false"}"
-  source           = "ELBSecurityPolicy-TLS-1-2-2017-01"
+  source           = "./ELBSecurityPolicy-TLS-1-2-2017-01"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"
@@ -32,7 +32,7 @@ module "ELBSecurityPolicy-TLS-1-2-2017-01" {
 
 module "ELBSample-ELBDefaultCipherPolicy" {
   create           = "${var.policy == "ELBSample-ELBDefaultCipherPolicy" ? "true" : "false"}"
-  source           = "ELBSample-ELBDefaultCipherPolicy"
+  source           = "./ELBSample-ELBDefaultCipherPolicy"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"
@@ -40,7 +40,7 @@ module "ELBSample-ELBDefaultCipherPolicy" {
 
 module "mozilla-old" {
   create           = "${var.policy == "mozilla-old" ? "true" : "false"}"
-  source           = "mozilla-old"
+  source           = "./mozilla-old"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"
@@ -48,7 +48,7 @@ module "mozilla-old" {
 
 module "mozilla-intermediate" {
   create           = "${var.policy == "mozilla-intermediate" ? "true" : "false"}"
-  source           = "mozilla-intermediate"
+  source           = "./mozilla-intermediate"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"
@@ -56,7 +56,7 @@ module "mozilla-intermediate" {
 
 module "ELBSecurityPolicy-2016-08" {
   create           = "${var.policy == "ELBSecurityPolicy-2016-08" ? "true" : "false"}"
-  source           = "ELBSecurityPolicy-2016-08"
+  source           = "./ELBSecurityPolicy-2016-08"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"
@@ -64,7 +64,7 @@ module "ELBSecurityPolicy-2016-08" {
 
 module "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" {
   create           = "${var.policy == "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" ? "true" : "false"}"
-  source           = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+  source           = "./ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"
@@ -72,7 +72,7 @@ module "ELBSecurityPolicy-TLS-1-2-Ext-2018-06" {
 
 module "tls-1-1-no-rsa" {
   create           = "${var.policy == "tls-1-1-no-rsa" ? "true" : "false"}"
-  source           = "tls-1-1-no-rsa"
+  source           = "./tls-1-1-no-rsa"
   lb-port          = "${var.lb-port}"
   name             = "${var.name}-ssl-policy"
   load-balancer-id = "${var.load-balancer-id}"


### PR DESCRIPTION
Terraform 0.12 [now requires](https://www.terraform.io/docs/modules/sources.html#local-paths) module paths to be prefixed with `./`. This PR switches the submodule source references to `./` relative paths. 

Fixes #9 

Tested with both 0.11 and 0.12.

Before: 

```
$ terraform  --version
Terraform v0.12.7

$ terraform init
Error: Module not found

The module address "ELBSample-ELBDefaultCipherPolicy" could not be resolved.

If you intended this as a path relative to the current module, use
"./ELBSample-ELBDefaultCipherPolicy" instead. The "./" prefix indicates that
the address is a relative filesystem path.
...
```

After:

```
$ terraform init
Initializing modules...
- module.ssl-policy
  Getting source "github.com/eheydrick/terraform-aws-ssl-ciphers"
- module.ssl-policy.ELBSample-OpenSSLDefaultCipherPolicy
  Getting source "ELBSample-OpenSSLDefaultCipherPolicy"
- module.ssl-policy.mozilla-modern
  Getting source "mozilla-modern"
- module.ssl-policy.ELBSecurityPolicy-TLS-1-1-2017-01
  Getting source "ELBSecurityPolicy-TLS-1-1-2017-01"
- module.ssl-policy.ELBSecurityPolicy-TLS-1-2-2017-01
  Getting source "ELBSecurityPolicy-TLS-1-2-2017-01"
- module.ssl-policy.ELBSample-ELBDefaultCipherPolicy
  Getting source "ELBSample-ELBDefaultCipherPolicy"
- module.ssl-policy.mozilla-old
  Getting source "mozilla-old"
- module.ssl-policy.mozilla-intermediate
  Getting source "mozilla-intermediate"
- module.ssl-policy.ELBSecurityPolicy-2016-08
  Getting source "ELBSecurityPolicy-2016-08"
- module.ssl-policy.ELBSecurityPolicy-TLS-1-2-Ext-2018-06
  Getting source "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
- module.ssl-policy.tls-1-1-no-rsa
  Getting source "tls-1-1-no-rsa"
```